### PR TITLE
Add gitattributes to reduce unnecessary files from composer installs.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.editorconfig export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/doc/ export-ignore
+/ext/twig/.gitignore export-ignore
+/phpunit.xml.dist export-ignore
+/test export-ignore

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         },
         {
             "name": "Twig Team",
-            "homepage": "https://github.com/fabpot/Twig/graphs/contributors",
+            "homepage": "http://twig.sensiolabs.org/contributors",
             "role": "Contributors"
         },
         {

--- a/doc/advanced.rst
+++ b/doc/advanced.rst
@@ -503,7 +503,7 @@ to host all the specific tags and filters you want to add to Twig.
 .. note::
 
     Before writing your own extensions, have a look at the Twig official
-    extension repository: http://github.com/fabpot/Twig-extensions.
+    extension repository: http://github.com/twigphp/Twig-extensions.
 
 An extension is a class that implements the following interface::
 
@@ -830,5 +830,5 @@ Testing the node visitors can be complex, so extend your test cases from
 
 .. _`spl_autoload_register()`: http://www.php.net/spl_autoload_register
 .. _`rot13`:                   http://www.php.net/manual/en/function.str-rot13.php
-.. _`tests/Twig/Fixtures`:     https://github.com/fabpot/Twig/tree/master/test/Twig/Tests/Fixtures
-.. _`tests/Twig/Node`:         https://github.com/fabpot/Twig/tree/master/test/Twig/Tests/Node
+.. _`tests/Twig/Fixtures`:     https://github.com/twigphp/Twig/tree/master/test/Twig/Tests/Fixtures
+.. _`tests/Twig/Node`:         https://github.com/twigphp/Twig/tree/master/test/Twig/Tests/Node

--- a/doc/advanced_legacy.rst
+++ b/doc/advanced_legacy.rst
@@ -529,7 +529,7 @@ to host all the specific tags and filters you want to add to Twig.
 .. note::
 
     Before writing your own extensions, have a look at the Twig official
-    extension repository: http://github.com/fabpot/Twig-extensions.
+    extension repository: http://github.com/twigphp/Twig-extensions.
 
 An extension is a class that implements the following interface::
 
@@ -883,5 +883,5 @@ Testing the node visitors can be complex, so extend your test cases from
 
 .. _`spl_autoload_register()`: http://www.php.net/spl_autoload_register
 .. _`rot13`:                   http://www.php.net/manual/en/function.str-rot13.php
-.. _`tests/Twig/Fixtures`:     https://github.com/fabpot/Twig/tree/master/test/Twig/Tests/Fixtures
-.. _`tests/Twig/Node`:         https://github.com/fabpot/Twig/tree/master/test/Twig/Tests/Node
+.. _`tests/Twig/Fixtures`:     https://github.com/twigphp/Twig/tree/master/test/Twig/Tests/Fixtures
+.. _`tests/Twig/Node`:         https://github.com/twigphp/Twig/tree/master/test/Twig/Tests/Node

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -28,7 +28,7 @@ Installing the development version
 
 .. code-block:: bash
 
-    git clone git://github.com/fabpot/Twig.git
+    git clone git://github.com/twigphp/Twig.git
 
 Installing the PEAR package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,7 +107,7 @@ advantage of the C extension. Note that this extension does not replace the
 PHP code but only provides an optimized version of the
 ``Twig_Template::getAttribute()`` method.
 
-.. _`download page`: https://github.com/fabpot/Twig/tags
-.. _`Composer`: https://getcomposer.org/download/
+.. _`download page`:     https://github.com/twigphp/Twig/tags
+.. _`Composer`:          https://getcomposer.org/download/
 .. _`PHP documentation`: https://wiki.php.net/internals/windows/stepbystepbuild
-.. _`Zend Server FAQ`: http://www.zend.com/en/products/server/faq#faqD6
+.. _`Zend Server FAQ`:   http://www.zend.com/en/products/server/faq#faqD6

--- a/doc/templates.rst
+++ b/doc/templates.rst
@@ -866,7 +866,7 @@ Extension<creating_extensions>` chapter.
 .. _`Twig syntax plugin`:         http://plugins.netbeans.org/plugin/37069/php-twig
 .. _`Twig plugin`:                https://github.com/pulse00/Twig-Eclipse-Plugin
 .. _`Twig language definition`:   https://github.com/gabrielcorpse/gedit-twig-template-language
-.. _`extension repository`:       http://github.com/fabpot/Twig-extensions
+.. _`extension repository`:       http://github.com/twigphp/Twig-extensions
 .. _`Twig syntax mode`:           https://github.com/bobthecow/Twig-HTML.mode
 .. _`other Twig syntax mode`:     https://github.com/muxx/Twig-HTML.mode
 .. _`Notepad++ Twig Highlighter`: https://github.com/Banane9/notepadplusplus-twig


### PR DESCRIPTION
When using the composer argument `--prefer-dist`, git archives will be used. This reduces files that are typically useless when using Twig as a library, as opposed to developing it. When using Twig as a library, and deploying, tests and raw documentation are unnecessary. When developing Twig, the preferred method is a git clone, and will continue to work properly.