### PR TITLE
Twig_TokenParser_Include cannot be final

### DIFF
--- a/lib/Twig/TokenParser/Include.php
+++ b/lib/Twig/TokenParser/Include.php
@@ -18,8 +18,6 @@
  *     Body
  *   {% include 'footer.html' %}
  * </pre>
- *
- * @final
  */
 class Twig_TokenParser_Include extends Twig_TokenParser
 {


### PR DESCRIPTION
Fixes `User Deprecated: The "Twig_TokenParser_Include" class is considered final. It may change without further notice as of its next major version. You should not extend it from "Twig_TokenParser_Embed".` on 1.x

See https://github.com/twigphp/Twig/pull/2288#issuecomment-304039530

cc @fabpot 